### PR TITLE
"relays[,]" should be an associative array...

### DIFF
--- a/etc/init.d/socat
+++ b/etc/init.d/socat
@@ -34,7 +34,7 @@ fi
 mkdir -p $SOCAT_CONF_DIR
 mkdir -p $SOCAT_PID_DIR
 
-declare -a relays
+declare -A relays
 declare -i relay_count
 relay_count=0
 


### PR DESCRIPTION
"relays[,]" should be an associative array to simulate a two-dimensional array.
Otherwise only the last configuration will be started.